### PR TITLE
Adding COLING 2022 Pan-DL paper

### DIFF
--- a/clulab_publications.bib
+++ b/clulab_publications.bib
@@ -1,3 +1,38 @@
+@inproceedings{nitschke-etal-2022-rule,
+    title = "Rule Based Event Extraction for Artificial Social Intelligence",
+    author = "Nitschke, Remo  and
+      Wang, Yuwei  and
+      Chen, Chen  and
+      Pyarelal, Adarsh  and
+      Sharp, Rebecca",
+    booktitle = "Proceedings of the First Workshop on Pattern-based Approaches to NLP in the Age of Deep Learning",
+    month = oct,
+    year = "2022",
+    address = "Gyeongju, Republic of Korea",
+    publisher = "International Conference on Computational Linguistics",
+    url = "https://aclanthology.org/2022.pandl-1.9",
+    pages = "71--84",
+    abstract = "Natural language (as opposed to structured communication modes
+        such as Morse code) is by far the most common mode of communication
+        between humans, and can thus provide significant insight into both
+        individual mental states and interpersonal dynamics. As part of
+        DARPA{'}s Artificial Social Intelligence for Successful Teams (ASIST)
+        program, we are developing an AI agent team member that constructs and
+        maintains models of their human teammates and provides appropriate
+        task-relevant advice to improve team processes and mission performance.
+        One of the key components of this agent is a module that uses a
+        rule-based approach to extract task-relevant events from natural
+        language utterances in real time, and publish them for consumption by
+        downstream components. In this case study, we evaluate the performance
+        of our rule-based event extraction system on a recently conducted ASIST
+        experiment consisting of a simulated urban search and rescue mission in
+        Minecraft. We compare the performance of our approach with that of a
+        zero-shot neural classifier, and find that our approach outperforms the
+        classifier for all event types, even when the classifier is used in an
+        oracle setting where it knows how many events should be extracted from
+        each utterance.",
+}
+
 @inproceedings{xu-bethard-2021-triplet,
     title = "Triplet-Trained Vector Space and Sieve-Based Search Improve Biomedical Concept Normalization",
     author = "Xu, Dongfang  and
@@ -167,7 +202,7 @@
   title={Using the Hammer Only on Nails: A Hybrid Method for Evidence Retrieval for Question Answering},
   author={Liang, Zhengzhong and Zhao, Yiyun and Surdeanu, Mihai},
   journal={arXiv preprint arXiv:2009.10791},
-  url = "https://arxiv.org/abs/2009.10791", 
+  url = "https://arxiv.org/abs/2009.10791",
   year={2020}
 }
 
@@ -365,19 +400,19 @@
   url={http://ai2-website.s3.amazonaws.com/publications/ValenzuelaHaMeaningfulCitations.pdf}
 }
 @inproceedings{Jansen:14,
-	year = {2014}, 
+	year = {2014},
 	author = {Jansen, Peter and Surdeanu, Mihai and Clark, Peter},
-	booktitle = {Proceedings of the 52nd Annual Meeting of the Association for Computational Linguistics (ACL)}, 
-	title = {Discourse Complements Lexical Semantics for Non-factoid Answer Reranking}, 
+	booktitle = {Proceedings of the 52nd Annual Meeting of the Association for Computational Linguistics (ACL)},
+	title = {Discourse Complements Lexical Semantics for Non-factoid Answer Reranking},
   url = {http://clulab.org/papers/acl2014.pdf},
   url_Code_And_Data = {http://nlp.sista.arizona.edu/releases/acl2014/},
   url_Slides = {http://nlp.sista.arizona.edu/releases/acl2014/},
 }
 @inproceedings{Manning:14,
-	year = {2014}, 
+	year = {2014},
 	author = {Manning, Christopher D. and Surdeanu, Mihai and Bauer, John and Finkel, Jenny and Bethard, Steven J. and McClosky, David},
-	booktitle = {Proceedings of the 52nd Annual Meeting of the Association for Computational Linguistics (ACL)}, 
-	title = {The Stanford CoreNLP Natural Language Processing Toolkit}, 
+	booktitle = {Proceedings of the 52nd Annual Meeting of the Association for Computational Linguistics (ACL)},
+	title = {The Stanford CoreNLP Natural Language Processing Toolkit},
   url = {http://clulab.org/papers/acl2014-corenlp.pdf},
   url_Code = {http://nlp.stanford.edu/software/corenlp.shtml},
 }
@@ -390,10 +425,10 @@
   url_Code  = {https://github.com/sistanlp/processors},
 }
 @inproceedings{Fried:14,
-	year = {2014}, 
+	year = {2014},
 	author = {Fried, Daniel and Surdeanu, Mihai and Kobourov, Stephen and Hingle, Melanie and Bell, Dane},
-	booktitle = {Proceedings of the 2014 IEEE International Conference on Big Data}, 
-	title = {Analyzing the Language of Food on Social Media}, 
+	booktitle = {Proceedings of the 2014 IEEE International Conference on Big Data},
+	title = {Analyzing the Language of Food on Social Media},
   url = {http://clulab.org/papers/bigdata2014.pdf},
   url_Supplmental_Material = {http://arxiv.org/abs/1409.2195},
   url_Demo = {https://sites.google.com/site/twitter4food/},
@@ -440,42 +475,42 @@
   url_Data_and_Code = {http://clulab.org/data/emnlp2016-causal/},
 }
 @inproceedings{surdeanu2013-icail,
-	year = {2013}, 
+	year = {2013},
 	author = {Mihai Surdeanu and Sara Jeruss},
-	booktitle = {Proceedings of the XIV International Conference on Artificial Intelligence and Law (ICAIL)}, 
-	title = {Identifying Patent Monetization Entities}, 
+	booktitle = {Proceedings of the XIV International Conference on Artificial Intelligence and Law (ICAIL)},
+	title = {Identifying Patent Monetization Entities},
   url = {http://clulab.org/papers/icail2013.pdf},
 }
 @inproceedings{Surdeanu:13,
-	year = {2013}, 
+	year = {2013},
 	author = {Surdeanu, Mihai},
-	booktitle = {Proceedings of the TAC-KBP 2013 Workshop}, 
-	title = {Overview of the TAC2013 Knowledge Base Population Evaluation: English Slot Filling and Temporal Slot Filling}, 
+	booktitle = {Proceedings of the TAC-KBP 2013 Workshop},
+	title = {Overview of the TAC2013 Knowledge Base Population Evaluation: English Slot Filling and Temporal Slot Filling},
   url = {http://clulab.org/papers/kbp2013.pdf},
   url_Slides_SF = {http://clulab.org/papers/kbp2013_sf.pdf},
   url_Slides_TSF = {http://clulab.org/papers/kbp2013_tsf.pdf},
 }
 @inproceedings{SurdeanuHeng:14,
-	year = {2014}, 
+	year = {2014},
 	author = {Surdeanu, Mihai and Heng, Ji},
-	booktitle = {Proceedings of the TAC-KBP 2014 Workshop}, 
-	title = {Overview of the English Slot Filling Track at the TAC2014 Knowledge Base Population Evaluation}, 
+	booktitle = {Proceedings of the TAC-KBP 2014 Workshop},
+	title = {Overview of the English Slot Filling Track at the TAC2014 Knowledge Base Population Evaluation},
   url = {http://clulab.org/papers/kbp2014_draft.pdf},
 }
 @inproceedings{Reschke:14,
-	year = {2014}, 
+	year = {2014},
 	author = {Reschke, Kevin and Jankowiak, Martin and Surdeanu, Mihai and Manning, Christopher D. and Jurafsky, Dan},
-	booktitle = {Proceedings of the 9th edition of the Language Resources and Evaluation Conference (LREC)}, 
-	title = {Event Extraction Using Distant Supervision}, 
+	booktitle = {Proceedings of the 9th edition of the Language Resources and Evaluation Conference (LREC)},
+	title = {Event Extraction Using Distant Supervision},
   url = {http://clulab.org/papers/lrec2014_ds.pdf},
   url_Data = {http://nlp.stanford.edu/projects/dist-sup-event-extraction.shtml},
   url_Slides = {http://clulab.org/papers/lrec2014_ds_slides.pdf}
 }
 @inproceedings{Lee:14,
-	year = {2014}, 
+	year = {2014},
 	author = {Lee, Heeyoung and MacCartney, Bill and Surdeanu, Mihai and Jurafsky, Dan},
-	booktitle = {Proceedings of the 9th edition of the Language Resources and Evaluation Conference (LREC)}, 
-	title = {On the Importance of Text Analysis for Stock Price Prediction}, 
+	booktitle = {Proceedings of the 9th edition of the Language Resources and Evaluation Conference (LREC)},
+	title = {On the Importance of Text Analysis for Stock Price Prediction},
   url = {http://clulab.org/papers/lrec2014_stocks.pdf},
   url_Data = {http://nlp.stanford.edu/pubs/stock-event.html},
   url_Slides = {http://clulab.org/papers/lrec2014_stocks_slides.pdf},
@@ -529,17 +564,17 @@
   url_Data_and_Some_Code = {http://surdeanu.cs.arizona.edu/mihai/papers/straw2gold.zip},
 }
 @inproceedings{intxaurrondo13,
-	year = {2013}, 
+	year = {2013},
 	author = {Ander Intxaurrondo and Mihai Surdeanu and Oier Lopez de Lacalle and Eneko Agirre},
-	booktitle = {Proceedings of the 29th "Congreso de la Sociedad Espa{\~{n}}ola para el Procesamiento del Lenguaje Natural" (SEPLN 2013)}, 
-	title = {Removing Noisy Mentions for Distant Supervision}, 
+	booktitle = {Proceedings of the 29th "Congreso de la Sociedad Espa{\~{n}}ola para el Procesamiento del Lenguaje Natural" (SEPLN 2013)},
+	title = {Removing Noisy Mentions for Distant Supervision},
   url = {http://clulab.org/papers/sepln13.pdf},
 }
 @inproceedings{Tran:14,
-	year = {2014}, 
+	year = {2014},
 	author = {Tran, Anh and Surdeanu, Mihai and Cohen, Paul},
-	booktitle = {Proceedings of the Third Joint Conference on Lexical and Computational Semantics (*SEM)}, 
-	title = {Extracting Latent Attributes from Video Scenes Using Text as Background Knowledge}, 
+	booktitle = {Proceedings of the Third Joint Conference on Lexical and Computational Semantics (*SEM)},
+	title = {Extracting Latent Attributes from Video Scenes Using Text as Background Knowledge},
   url = {http://clulab.org/papers/starsem2014.pdf},
   url_Slides = {http://clulab.org/papers/starsem2014_slides.pdf},
 }
@@ -576,10 +611,10 @@ over their first-order variants. },
         pages = {197-210}
 }
 @inproceedings{Forbes:13,
-	year = {2013}, 
+	year = {2013},
 	author = {Angus Forbes and Mihai Surdeanu and Peter Jansen and Jane Carrington},
-	booktitle = {Proceedings of the 3rd IEEE Workshop on Interactive Visual Text Analytics}, 
-	title = {Transmitting Narrative: An Interactive Shift-Summarization Tool for Improving Nurse Communication}, 
+	booktitle = {Proceedings of the 3rd IEEE Workshop on Interactive Visual Text Analytics},
+	title = {Transmitting Narrative: An Interactive Shift-Summarization Tool for Improving Nurse Communication},
   url = {http://clulab.org/papers/textvis2013.pdf},
 }
 @article{valenzuela2015description,
@@ -773,7 +808,7 @@ url={http://clulab.org/papers/biocreative6.pdf}
  title = {A Study of Automatically Acquiring Explanatory Inference Patterns from Corpora of Explanations: Lessons from Elementary Science Exams},
  booktitle = {Proceedings of the 2017 Workshop on Automated Knowledge Base Construction},
  series = {AKBC'17},
- year = {2017}, 
+ year = {2017},
  url = {http://cognitiveai.org/wp-content/uploads/2017/11/jansen_akbc2017_automatically_acquiring_explanatory_inference_patterns_from_corpora_of_explanations.pdf},
  url_data = {http://cognitiveai.org/explanationbank/}
 }
@@ -808,7 +843,7 @@ url={http://clulab.org/papers/biocreative6.pdf}
 @inproceedings{whitespaces-identification2018,
   title={Scientific Discovery as Link Prediction in Influence and Citation Graphs},
   author={Fan Luo and
-      	Marco A. Valenzuela-Escarcega and 
+      	Marco A. Valenzuela-Escarcega and
         Gus Hahn-Powell and
         Mihai Surdeanu},
   booktitle = {TextGraphs: 12th Workshop on Graph-Based Natural Language Processing},
@@ -1096,12 +1131,12 @@ keywords = {information retrieval, recommender systems, machine learning},
   url = 	"http://aclweb.org/anthology/C18-1182"
 }
 @InProceedings{bell2018detecting,
-  title	    = {Detecting diabetes risk from social media activity}, 
-  author    = {Bell, Dane and Laparra, Egoitz and Kousik, Aditya and Ishihara, Terron and Surdeanu, Mihai and Kobourov, Stephen}, 
-  booktitle = {Ninth International Workshop on Health Text Mining and Information Analysis (LOUHI)}, 
+  title	    = {Detecting diabetes risk from social media activity},
+  author    = {Bell, Dane and Laparra, Egoitz and Kousik, Aditya and Ishihara, Terron and Surdeanu, Mihai and Kobourov, Stephen},
+  booktitle = {Ninth International Workshop on Health Text Mining and Information Analysis (LOUHI)},
   year      = {2018},
   url = {http://clulab.org/papers/louhi2018-t2dmrisk.pdf},
-  url_Slides = {http://clulab.org/papers/louhi2018-emnlp.pptx} 
+  url_Slides = {http://clulab.org/papers/louhi2018-emnlp.pptx}
 }
 @Article{Zhou:2018,
   author    = {Jun Zhou and Dane Bell and Sabina Nusrat and Melanie D.\ Hingle and Mihai Surdeanu and Stephen Kobourov},
@@ -1294,12 +1329,12 @@ url={http://clulab.org/papers/meanteacherre19.pdf}
     url_Poster = "http://clulab.org/papers/emnlp2019-rocc-poster.pdf"
 }
 @InProceedings{van2019language,
-  title	    = {What does the language of foods say about us?}, 
-  author    = {Van, Hoang and Musa, Ahmad and Chen, Hang and Surdeanu, Mihai and Kobourov, Stephen}, 
-  booktitle = {Tenth International Workshop on Health Text Mining and Information Analysis (LOUHI)}, 
+  title	    = {What does the language of foods say about us?},
+  author    = {Van, Hoang and Musa, Ahmad and Chen, Hang and Surdeanu, Mihai and Kobourov, Stephen},
+  booktitle = {Tenth International Workshop on Health Text Mining and Information Analysis (LOUHI)},
   year      = {2019},
   url = {http://clulab.org/papers/louhi2019.pdf},
-  url_Slides = {http://clulab.org/papers/louhi2019.pptx} 
+  url_Slides = {http://clulab.org/papers/louhi2019.pptx}
 }
 @inproceedings{suntwal-etal-2019-importance,
     title = "On the Importance of Delexicalization for Fact Verification",
@@ -1478,7 +1513,7 @@ the retrieved sentences; and (c) effective and faithful explanations when answer
     url = "https://aclanthology.org/2022.insights-1.22",
     pages = "159--164",
     abstract = "In this paper, we introduce and justify a new task{---}causal link extraction based on beliefs{---}and do a qualitative analysis of the ability of a large language model{---}InstructGPT-3{---}to generate implicit consequences of beliefs. With the language model-generated consequences being promising, but not consistent, we propose directions of future work, including data collection, explicit consequence extraction using rule-based and language modeling-based approaches, and using explicitly stated consequences of beliefs to fine-tune or prompt the language model to produce outputs suitable for the task.",
-} 
+}
 @inproceedings{zupon2022lparsinglrec,
 	title={Automatic Correction of Syntactic Dependency Annotation Differences},
 	author={Zupon, Andrew and Carnie, Andrew and Hammond, Michael and Surdeanu, Mihai},
@@ -1738,4 +1773,3 @@ keywords = {environmental policy},
     pages = "458--466",
     keywords = {domain adaptation, negation, timelines, information extraction, health applications, shared task paper},
 }
-


### PR DESCRIPTION
This PR adds our paper from the COLING 2022 Pan-DL workshop. It also removes some trailing whitespace from other entries in the .bib file.